### PR TITLE
feat: add action store

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Composition API and supporting libraries for writing functional Angular applicat
 |---|---|
 | [Core](https://github.com/mmuscat/angular-composition-api/tree/master/packages/core) | A lightweight (3kb) library for writing functional Angular applications.
 | [Boundary](https://github.com/mmuscat/angular-composition-api/tree/master/packages/boundary) | A lightweight (3kb) implementation of [Error Boundaries](https://reactjs.org/docs/error-boundaries.html) for Angular, with a bit of [Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html).
+| [Store](https://github.com/mmuscat/angular-composition-api/tree/master/packages/store) | A delightfully concise (1kb) redux store for Angular applications
 | [Example](https://github.com/mmuscat/angular-composition-api/tree/master/packages/example) | Todo List sandbox.
 
 ## Contributing

--- a/angular.json
+++ b/angular.json
@@ -174,6 +174,37 @@
           }
         }
       }
+    },
+    "store": {
+      "projectType": "library",
+      "root": "packages/store",
+      "sourceRoot": "packages/store/src",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "project": "packages/store/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "packages/store/tsconfig.lib.prod.json"
+            },
+            "development": {
+              "tsConfig": "packages/store/tsconfig.lib.json"
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "packages/store/src/test.ts",
+            "tsConfig": "packages/store/tsconfig.spec.json",
+            "karmaConfig": "packages/store/karma.conf.js"
+          }
+        }
+      }
     }
   },
   "defaultProject": "core"

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -1,0 +1,148 @@
+# Angular Actions
+
+A delightfully concise (1kb) redux store for Angular applications.
+
+## Quick Start
+
+Install via NPM
+
+```bash
+npm install @mmuscat/angular-actions
+```
+
+Install via Yarn
+
+```bash
+yarn add @mmuscat/angular-actions
+```
+
+### Create a store
+
+Define some actions
+
+```ts
+const Increment = Action("Increment")
+const actions = [CreateTodo]
+```
+
+Define the action union type for your reducer
+
+```
+type Actions = ActionUnion<typeof actions>
+```
+
+Create the reducer
+
+```ts
+function reducer(state: number, action: Actions) {
+    switch (action.kind) {
+        case Increment.kind: {
+            return state + 1
+        }
+    }
+    return state
+}
+```
+
+Configure a store in your directive, component or service.
+
+```ts
+function create() {
+    const { state, action } = Store(reducer, 0, actions)
+
+    action.Increment()
+    
+    Subscribe(state, (value) => {
+        console.log("state changed!", value)
+    })
+    
+    return {
+        state,
+        ...action,
+    }
+}
+```
+
+### Use effects
+
+Define some actions
+
+```ts
+const AddTodo = Action("AddTodo", props<Todo>())
+const AddTodoDone = Action("AddTodoDone", props<Todo>())
+const AddTodoError = Action("AddTodoError", props<any>())
+
+const actions = [AddTodo, AddTodoDone, AddTodoError]
+```
+
+Create some effects
+
+```ts
+const addTodo = Effect(AddTodo, (state: StateRef<Todo[]>) => {
+    const http = Inject(HttpClient)
+    
+    return mergeMap((todo) => {
+        http.post(`//example.com/api/v1/todo`, todo).pipe(
+            action(AddTodoDone, AddTodoError)        
+        )
+    })
+})
+
+const effects = [addTodo]
+```
+
+Use effects with a store
+
+```ts
+function reducer(state: Todo[], action: Actions) {
+    switch(action.kind) {
+        case AddTodoDone.kind: {
+            return state.concat(action.data)
+        }
+    }
+    return state
+}
+
+function create() {
+    const initialState: Todo[] = []
+    const store = Store(reducer, initialState, actions)
+    
+    UseEffects(store, effects)
+    
+    return store
+}
+
+```
+
+## API Reference
+
+### Action
+
+Creates an action factory of a `kind`, with or without data.
+
+### Effect
+
+Creates an effect factory.
+
+### Store
+
+Takes a `reducer`, `initialValue` and `actions` array. Returns a store
+with reactive `state`. Actions are mapped to `action` keys as bound
+functions that will emit actions of that type when invoked. The
+returned store is an observable of actions that have been broadcast,
+*after* the state has updated.
+
+### UseEffects
+
+Run an array of `effects` against the given store and return a subscription
+that can be used to stop them.
+
+### kindOf
+
+An `OperatorFunction` that filters a stream of `Action` to the
+actions listed in its arguments.
+
+### action
+
+An `OperatorFunction` that maps a stream of data to the given `action`,
+optionally catching and mapping errors to the provided `errorAction`. 

--- a/packages/store/karma.conf.js
+++ b/packages/store/karma.conf.js
@@ -1,0 +1,44 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../coverage/store'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/packages/store/ng-package.json
+++ b/packages/store/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/store",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@mmuscat/angular-actions",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^12.0.4",
+    "@angular/core": "^12.0.4",
+    "@mmuscat/angular-composition-api": "^0.1200.0-next.4"
+  },
+  "dependencies": {
+    "tslib": "^2.1.0"
+  }
+}

--- a/packages/store/src/public-api.ts
+++ b/packages/store/src/public-api.ts
@@ -1,0 +1,5 @@
+/*
+ * Public API Surface of store
+ */
+
+export * from "./store"

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,0 +1,126 @@
+import {MonoTypeOperatorFunction, of, OperatorFunction, queueScheduler, scheduled, Subject, throwError} from "rxjs";
+import {Subscribe, Value, ValueSubject} from "@mmuscat/angular-composition-api";
+import {catchError, filter, map} from "rxjs/operators";
+
+type ActionDispatcher<T extends ActionFactory, TKeys extends string = T["kind"]> = {
+    [key in TKeys]: (value: T extends ActionFactory<key, infer R> ? ReturnType<R> : never) => void
+}
+
+export class StoreSubject<T extends Action, U = any, V extends ActionFactory<any, any>[] = []> extends Subject<T> {
+    #reducer: (state: U, action: T) => U
+    next(value: T): void
+    next(value: T extends Action<infer R> ? { kind: R } : never): void
+    next(value: any) {
+        this.state.next(this.#reducer(this.state.value, value))
+        super.next(value)
+    }
+    action: ActionDispatcher<V[number]>
+    state: ValueSubject<U>
+    constructor(state: ValueSubject<U>, reducer: (state: U, action: T) => U, actions: V) {
+        super()
+        this.#reducer = reducer
+        this.state = state
+        this.action = actions.reduce((acc, next) => {
+            acc[next.kind] = (...args: any[]) => {
+                this.next(next(...args) as any)
+            }
+            return acc
+        }, {} as any)
+        return Object.create(this, {
+            action: {
+                enumerable: true,
+                value: this.action
+            },
+            state: {
+                enumerable: true,
+                value: this.state
+            }
+        })
+    }
+}
+
+type TArgs<T> = T extends (...args: infer R) => any ? R : never
+
+export interface Action<T extends string = string, U = unknown> {
+    readonly kind: T
+    readonly data: U
+}
+
+export type ActionFactory<T extends string = string, U extends (...args: any[]) => any = (...args: any[]) => unknown> = {
+    readonly kind: T,
+    (...args: TArgs<U>): Action<T, ReturnType<U>>
+}
+
+export function Store<T, U extends (ActionFactory)[]>(reducer: (state: T, action: ActionUnion<U>) => T, initialValue: T, actions?: U): StoreSubject<ActionUnion<U>, T, U>
+export function Store<T, U extends Action<any, any>>(reducer: (state: T, action: U) => T, initialValue: T): StoreSubject<U, T>
+export function Store<T>(reducer: (state: T, action: Action<any>) => T, initialValue: T): StoreSubject<Action<any>, T>
+export function Store<T>(reducer: (state: T, action: Action<any>) => T, initialValue: T, actions = []): StoreSubject<Action<any>, T> {
+    return new StoreSubject<any, T, any[]>(Value(initialValue), reducer, actions)
+}
+
+export type ActionUnion<T extends ActionFactory[]> = ReturnType<T[number]> & { kind: T[number]["kind"]}
+
+export function Action<T extends string, U extends (...args: any) => any>(kind: T): ActionFactory<T, () => void>
+export function Action<T extends string, U extends (...args: any) => any>(kind: T, data: U): ActionFactory<T, U>
+export function Action<T extends string, U extends (...args: any) => any>(kind: T, data: U = ((arg: any) => arg) as any): ActionFactory<T, U> {
+    function createAction(...args: TArgs<U>[]) {
+        return {
+            kind,
+            data: data(...args)
+        }
+    }
+    createAction.kind = kind
+    return createAction
+}
+
+function kindOf<T extends string>(...types: ActionFactory<T>[]): MonoTypeOperatorFunction<Action<T>> {
+    return function (source) {
+        return source.pipe(
+            filter((value) => types.some(type => value.kind === type.kind))
+        )
+    }
+}
+
+function UseEffects<T extends StoreSubject<any>, U extends Effect<any, EffectHandler<T extends StoreSubject<any, infer R> ? StateRef<R> : StateRef<unknown>, any>>[]>(dispatch: T, effects: U) {
+    const cleanup = Subscribe()
+    const stateRef = Object.freeze(Object.create(dispatch.state))
+    for (const effect of effects) {
+        const operator = effect.factory(stateRef)
+        const kinds = Array.isArray(effect.action) ? effect.action : [effect.action]
+        cleanup.add(scheduled(dispatch, queueScheduler).pipe(
+            kindOf(...kinds),
+            operator
+        ).subscribe(dispatch))
+    }
+    return cleanup
+}
+
+type EffectHandler<T, U> = (state: T) => OperatorFunction<U, Action>
+
+export interface Effect<T extends ActionFactory<any>, U extends EffectHandler<any, ReturnType<T>>> {
+    action: T,
+    factory: U
+}
+
+function Effect<T extends ActionFactory<any, any>, U extends (state: any) => OperatorFunction<ReturnType<T>, Action>>(action: T, factory: U): Effect<T, U>
+function Effect<T extends ActionFactory<any, any>, U extends (state: any) => OperatorFunction<ReturnType<T>, Action>>(action: T[], factory: U): Effect<T, U>
+function Effect<T extends ActionFactory<any, any>, U extends (state: any) => OperatorFunction<ReturnType<T>, Action>>
+(action: T, factory: U): Effect<T, U> {
+    return {
+        action,
+        factory
+    }
+}
+
+function action<T extends ActionFactory, U extends ActionFactory>(action: T, errorAction?: U): OperatorFunction<ReturnType<T>["data"], Action> {
+    return function (source) {
+        return source.pipe(
+            map(action),
+            catchError((error) => {
+                return errorAction ? of(errorAction(error)) : throwError(error)
+            })
+        )
+    }
+}
+
+export type StateRef<T> = Readonly<{ value: T }>

--- a/packages/store/src/test.ts
+++ b/packages/store/src/test.ts
@@ -1,0 +1,26 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js';
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/packages/store/tsconfig.lib.json
+++ b/packages/store/tsconfig.lib.json
@@ -1,0 +1,20 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/lib",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/store/tsconfig.lib.prod.json
+++ b/packages/store/tsconfig.lib.prod.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
+}

--- a/packages/store/tsconfig.spec.json
+++ b/packages/store/tsconfig.spec.json
@@ -1,0 +1,17 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,10 @@
       "@mmuscat/angular-error-boundary": [
         "./dist/boundary"
       ],
+      "@mmuscat/angular-actions": [
+        "dist/store/store",
+        "dist/store"
+      ],
     },
     "experimentalDecorators": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This PR adds a type-safe redux store for use with angular composition API. Create stores anywhere in directives, components or services, no modules required.